### PR TITLE
Update playerInfoStyles.css to include height property

### DIFF
--- a/playerInfo/playerInfoStyles.css
+++ b/playerInfo/playerInfoStyles.css
@@ -182,6 +182,7 @@ header {
 
 .playerBanner {
     width: min(600px, 70%);
+    height: min(75px,70%);
     /* border-width: 6px 12px 19px;
     border-style: solid;
     border-image-source: url(../assets/images/testBorder.webp);


### PR DESCRIPTION
Added height value to player banner to prevent prestige banners from interfering with the site's functionality

Note that this does not fix the full issue of mastery banners being displayed incorrectly (the animation would have to be recreated here to do that, since the API only provides the image that glides across the banner), it just prevents them (and future unsupported banners) from overlapping the rest of the page and making the "view matches" button unusable.

Example of change, before and after:
Before:
![image](https://github.com/SpoonOil/b2-website/assets/50807043/c926a4bd-1153-42e9-bd76-beb661810a06)

After:
![image](https://github.com/SpoonOil/b2-website/assets/50807043/eac95c0d-b19e-4b31-ab16-5a9998f49616)
