### PR TITLE
Add aspect-ratio to banner image based on default banner size

### DIFF
--- a/playerInfo/playerInfoStyles.css
+++ b/playerInfo/playerInfoStyles.css
@@ -182,6 +182,7 @@ header {
 
 .playerBanner {
     width: min(600px, 70%);
+    aspect-ratio: 1419/178; /* 1419px by 178px is the default banner size */
     /* border-width: 6px 12px 19px;
     border-style: solid;
     border-image-source: url(../assets/images/testBorder.webp);


### PR DESCRIPTION
Forces all banner images to follow the default aspect ratio, fixing some issues such as prestige banners covering the view matches button

Note that this does not fix the full issue of mastery banners being displayed incorrectly (the animation would have to be recreated here to do that, since the API only provides the image that glides across the banner), it just prevents them (and future unsupported banners) from overlapping the rest of the page and making the "view matches" button unusable.

Example of change, before and after:
Before:
![image](https://github.com/SpoonOil/b2-website/assets/50807043/e205a15f-a0e0-4219-bab8-f07397db3d0b)

After:
![image](https://github.com/SpoonOil/b2-website/assets/50807043/a234cf50-fea3-4fe3-b49f-25280e86f680)
