### PR TITLE
Added new maps and heroes, moved hero lists in playerInfoScript to one location

### DIFF
--- a/matchViewer/matchesScript.js
+++ b/matchViewer/matchesScript.js
@@ -21,7 +21,8 @@ const displayTerms = {
         ["sands_of_time", "Sands Of Time"],
         ["star", "Star"],
         ["pirate_cove", "Pirate Cove"],
-        ["precious_space", "Precious Space"]
+        ["precious_space", "Precious Space"],
+        ["sun_palace", "Sun Palace"]
     ],
     "towers": [
         ["DartMonkey", "Dart Monkey"],
@@ -67,7 +68,8 @@ const displayTerms = {
         ["Jericho", "Agent Jericho"],
         ["Agent_Jericho", "Agent Jericho"],
         ["Jericho_Highwayman", "Highwayman Jericho"],
-        ["Jericho_StarCaptain", "Star Captain Jericho"]
+        ["Jericho_StarCaptain", "Star Captain Jericho"],
+        ["Adora", "Adora"]
     ]
 }
 

--- a/playerInfo/playerInfoScript.js
+++ b/playerInfo/playerInfoScript.js
@@ -1,3 +1,7 @@
+//note: 2 names exist for agent and highwayman jericho, the old ones shouldn't show up anywhere anymore but were left just in case
+const heroTowers = ['Quincy', 'Quincy_Cyber', 'Gwendolin', 'Gwendolin_Science', 'Churchill', 'Churchill_Sentai', 'StrikerJones', 'StrikerJones_Biker', 'Obyn', 'Obyn_Ocean', 'Benjamin', 'Benjamin_DJ', 'Ezili', 'Ezili_SmudgeCat', 'PatFusty', 'PatFusty_Snowman', 'Agent_Jericho', 'Highwayman_Jericho', 'Jericho', 'Jericho_Highwayman', 'Jericho_StarCaptain', 'Adora']
+
+
 const submit = document.querySelector('.submit');
 const matchHistoryButton = document.querySelector('.matchHistoryButton');
 
@@ -90,8 +94,8 @@ function updateSummary(player) {
     'used': 0
   }
   for (let i = 0; i < towers.length; i++) {
-    tower = towers[i]
-    const heroTowers = ['Quincy', 'Quincy_Cyber', 'Gwendolin', 'Gwendolin_Science', 'Churchill', 'Churchill_Sentai', 'StrikerJones', 'StrikerJones_Biker', 'Obyn', 'Obyn_Ocean', 'Benjamin', 'Benjamin_DJ', 'Ezili', 'Ezili_SmudgeCat', 'PatFusty', 'PatFusty_Snowman', 'Agent_Jericho', 'Highwayman_Jericho']
+    tower = towers[i] 
+    //heroTowers moved to global scope
     if (tower == favoriteTower1 || tower == favoriteTower2 || tower == favoriteTower3) {
       continue
     }
@@ -154,7 +158,7 @@ function generateTowerRow(tower, heroTable, primaryTable, militaryTable, magicTa
   const magicTowers = ['Alchemist', 'SuperMonkey', 'NinjaMonkey', 'Druid', 'WizardMonkey']
   const militaryTowers = ['MonkeySub', 'MonkeyAce', 'HeliPilot', 'SniperMonkey', 'DartlingGunner', 'MonkeyBuccaneer', 'MortarMonkey']
   const supportTowers = ['BananaFarm', 'SpikeFactory', 'MonkeyVillage', 'EngineerMonkey', 'BeastHandler']
-  const heroTowers = ['Quincy', 'Quincy_Cyber', 'Gwendolin', 'Gwendolin_Science', 'Churchill', 'Churchill_Sentai', 'StrikerJones', 'StrikerJones_Biker', 'Obyn', 'Obyn_Ocean', 'Benjamin', 'Benjamin_DJ', 'Ezili', 'Ezili_SmudgeCat', 'PatFusty', 'PatFusty_Snowman', 'Agent_Jericho', 'Highwayman_Jericho']
+  //heroTowers moved to global scope
 
   //set tower class based on what list its in
   if (primaryTowers.includes(tower.type)) {


### PR DESCRIPTION
On the matches page, the old Jericho names were left in for backwards compatibility, though I'm not sure if that's a concern since the API shouldn't have any games left with that hero name. Those may be better off removed, though I'll leave it up to your discretion.

There were 2 places with a hard coded hero list in the playerInfoScript.js file - when they were updated, they were moved to one global hardcoded location instead, though I do wonder if having a separate global variable js file with all hero names, maps, etc. would be better since there would only be one spot to update everything.
