### PR TITLE
Player search rate limit prevention and erroneous rank/place result prevention

### DIFF
--- a/matchViewer/matchesScript.js
+++ b/matchViewer/matchesScript.js
@@ -286,6 +286,8 @@ function updatePlayerName(player, slot) {
 }
 
 let playerSideToggle = document.querySelector("#playerSideToggle");
+//prevents certain browsers from saving the checkbox state on refresh, desyncing the checkbox
+playerSideToggle.checked = false
 playerSideToggle.addEventListener("click", () => {togglePlayerSide()});
 
 function togglePlayerSide() {

--- a/matchViewer/matchesScript.js
+++ b/matchViewer/matchesScript.js
@@ -286,8 +286,6 @@ function updatePlayerName(player, slot) {
 }
 
 let playerSideToggle = document.querySelector("#playerSideToggle");
-//prevents certain browsers from saving the checkbox state on refresh, desyncing the checkbox
-playerSideToggle.checked = false
 playerSideToggle.addEventListener("click", () => {togglePlayerSide()});
 
 function togglePlayerSide() {

--- a/playerSearch/searchScript.js
+++ b/playerSearch/searchScript.js
@@ -48,6 +48,10 @@ function updateModeSegment(e) {
 
 function searchPlayers(e) {
     e.preventDefault();
+    
+    const searchButton = document.querySelector('.searchSubmit')
+    searchButton.disabled = true
+    
     const searchInput = document.querySelector('#searchBar');
     const searchValue = searchInput.value;
     const searchMode = document.querySelector('input[name="searchMode"]:checked').value
@@ -56,6 +60,8 @@ function searchPlayers(e) {
     resultsFound = 0;
     rankIndex = 1;
     searchAPI(searchValue, searchMode, 'https://data.ninjakiwi.com/battles2/homs/'+searchSeason+'/leaderboard');
+    
+    searchButton.disabled = false
 }
 
 function searchAPI(searchValue, searchMode, url) {

--- a/playerSearch/searchScript.js
+++ b/playerSearch/searchScript.js
@@ -1,4 +1,4 @@
-let resultFound = false;
+let resultsFound = 0;
 
 const hamburger = document.querySelector(".hamburger");
 const navMenu = document.querySelector(".toolList");
@@ -53,7 +53,7 @@ function searchPlayers(e) {
     const searchMode = document.querySelector('input[name="searchMode"]:checked').value
     const searchSeason = document.querySelector('input[name="searchSeason"]:checked').value
     clearChildren(document.querySelector('.resultsOutput'))
-    resultFound = false;
+    resultsFound = 0;
     rankIndex = 1;
     searchAPI(searchValue, searchMode, 'https://data.ninjakiwi.com/battles2/homs/'+searchSeason+'/leaderboard');
 }
@@ -76,18 +76,19 @@ function searchAPI(searchValue, searchMode, url) {
 
 function processData(json, searchMode, searchValue) {
     const players = json.body;
+    let resultsFound = 0;
     for (let i = 0; i < players.length; i++) {
         const player = players[i];
         if (searchMode == "name") {
             if (player.displayName.toLowerCase().includes(searchValue.toLowerCase())) {
-                resultFound = true;
-                generatePlayerCard(player, rankIndex);
+                resultsFound++;
+                generatePlayerCard(player, rankIndex, resultsFound<10);
             }
         }  else if (searchMode == "score") {
             if (searchValue.match(/^\d+$/) ) {//match numbers)
                 if (player.score.toString().includes(searchValue)) {
-                    resultFound = true;
-                    generatePlayerCard(player, rankIndex);
+                    resultsFound++;
+                    generatePlayerCard(player, rankIndex, resultsFound<10);
                 }
             } else {
                 let evalValue = searchValue;
@@ -98,16 +99,15 @@ function processData(json, searchMode, searchValue) {
                 // evalValue = evalValue.replace('==', '== player.score.toString()')
                 // evalValue = evalValue.replace('!=', '!= player.score.toString()')
                 if (eval(player.score.toString() + evalValue)) {
-                    resultFound = true;
-                    generatePlayerCard(player, rankIndex);
-
+                    resultsFound++;
+                    generatePlayerCard(player, rankIndex, resultsFound<10);
                 }
             }
         } else if (searchMode == "place") {
             if (searchValue.match(/^\d+$/) ) {//match numbers)
                 if (rankIndex == searchValue) {
-                    resultFound = true;
-                    generatePlayerCard(player, rankIndex);
+                    resultsFound++;
+                    generatePlayerCard(player, rankIndex, resultsFound<10);
                 }
             } else {
                 let evalValue = searchValue;
@@ -118,8 +118,8 @@ function processData(json, searchMode, searchValue) {
                 // evalValue = evalValue.replace('==', '== player.score.toString()')
                 // evalValue = evalValue.replace('!=', '!= player.score.toString()')
                 if (eval(rankIndex + evalValue)) {
-                    resultFound = true;
-                    generatePlayerCard(player, rankIndex);
+                    resultsFound++;
+                    generatePlayerCard(player, rankIndex, resultsFound<10);
 
                 }
             }
@@ -128,12 +128,12 @@ function processData(json, searchMode, searchValue) {
     }
     if (json.next) {
         searchAPI(searchValue, searchMode, json.next)
-    } else if (!resultFound) {
+    } else if (resultsFound == 0) {
         document.querySelector('.resultsOutput').innerHTML = 'No results found';
     }
 }
 
-function generatePlayerCard(player, rankIndex) {
+function generatePlayerCard(player, rankIndex, portraitRetrieval = true) {
     const playerCard = document.createElement('div');
     playerCard.classList.add('playerCard');
     console.log(rankIndex)
@@ -150,8 +150,11 @@ function generatePlayerCard(player, rankIndex) {
     `;
     document.querySelector('.resultsOutput').appendChild(playerCard);
     document.querySelector("#rank"+rankIndex.toString()).textContent = player.displayName;
-    const playerImage = playerCard.querySelector('.playerCardImage');
-    updatePlayerImages(player, playerImage)
+    
+    if(portraitRetrieval){
+        const playerImage = playerCard.querySelector('.playerCardImage');
+        updatePlayerImages(player, playerImage)
+    }
 }
 
 async function updatePlayerImages(player, playerImage) {

--- a/playerSearch/searchScript.js
+++ b/playerSearch/searchScript.js
@@ -76,7 +76,6 @@ function searchAPI(searchValue, searchMode, url) {
 
 function processData(json, searchMode, searchValue) {
     const players = json.body;
-    let resultsFound = 0;
     for (let i = 0; i < players.length; i++) {
         const player = players[i];
         if (searchMode == "name") {

--- a/playerSearch/searchScript.js
+++ b/playerSearch/searchScript.js
@@ -1,3 +1,4 @@
+const MAX_PORTRAITS = 10;
 let resultsFound = 0;
 
 const hamburger = document.querySelector(".hamburger");
@@ -87,13 +88,13 @@ function processData(json, searchMode, searchValue) {
         if (searchMode == "name") {
             if (player.displayName.toLowerCase().includes(searchValue.toLowerCase())) {
                 resultsFound++;
-                generatePlayerCard(player, rankIndex, resultsFound<10);
+                generatePlayerCard(player, rankIndex, resultsFound<MAX_PORTRAITS);
             }
         }  else if (searchMode == "score") {
             if (searchValue.match(/^\d+$/) ) {//match numbers)
                 if (player.score.toString().includes(searchValue)) {
                     resultsFound++;
-                    generatePlayerCard(player, rankIndex, resultsFound<10);
+                    generatePlayerCard(player, rankIndex, resultsFound<MAX_PORTRAITS);
                 }
             } else {
                 let evalValue = searchValue;
@@ -105,14 +106,14 @@ function processData(json, searchMode, searchValue) {
                 // evalValue = evalValue.replace('!=', '!= player.score.toString()')
                 if (eval(player.score.toString() + evalValue)) {
                     resultsFound++;
-                    generatePlayerCard(player, rankIndex, resultsFound<10);
+                    generatePlayerCard(player, rankIndex, resultsFound<MAX_PORTRAITS);
                 }
             }
         } else if (searchMode == "place") {
             if (searchValue.match(/^\d+$/) ) {//match numbers)
                 if (rankIndex == searchValue) {
                     resultsFound++;
-                    generatePlayerCard(player, rankIndex, resultsFound<10);
+                    generatePlayerCard(player, rankIndex, resultsFound<MAX_PORTRAITS);
                 }
             } else {
                 let evalValue = searchValue;
@@ -124,7 +125,7 @@ function processData(json, searchMode, searchValue) {
                 // evalValue = evalValue.replace('!=', '!= player.score.toString()')
                 if (eval(rankIndex + evalValue)) {
                     resultsFound++;
-                    generatePlayerCard(player, rankIndex, resultsFound<10);
+                    generatePlayerCard(player, rankIndex, resultsFound<MAX_PORTRAITS);
 
                 }
             }


### PR DESCRIPTION
Fixes #23 and #49 

Prevents rate limiting the user if they type too small of a search by preventing players after the first 10 from showing avatars
Prevents erroneous rank/place results by preventing the search button from being pressed after a search has began