### PR TITLE
Seasonal Winrate display on profiles

### DIFF
--- a/clanViewer/clan.js
+++ b/clanViewer/clan.js
@@ -18,7 +18,7 @@ async function showContent() {
   document.querySelector(".loadingContainer").classList.remove("loading")
   document.querySelector(".content").classList.add("contentShow")
 }
-
+ 
 async function generateClanContent(json) {
   clanBanner(json)
   clanData(json)

--- a/playerInfo/playerInfo.html
+++ b/playerInfo/playerInfo.html
@@ -75,17 +75,19 @@
         </h3>
         <section class="summaryContent">
           <div class="winrateContainer">
-            <h4 class="winrateHeader">
-              Winrate
-            </h4>
-            <p class="winrateNum">69%</p>
+            <div class="winrate">
+              <h4 class="winrateHeader">
+                Winrate
+              </h4>
+              <p class="winrateNum">69%</p>
+            </div>
           </div>
           <div class="mostUsedContainer">
             <h4 class="mostUsedHeader">
               Most Used Towers
             </h4>
             <p class="mostUsedTowers">
-              <span class = "tower1"></span>
+              <span class="tower1"></span>
               <span class="tower2"></span>
               <span class="tower3"></span>
             </p>

--- a/playerInfo/playerInfoStyles.css
+++ b/playerInfo/playerInfoStyles.css
@@ -300,10 +300,18 @@ section.summaryContent {
 
 .winrateContainer {
     flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 48px;
+}
+
+.winrate {
+
 }
 
 .mostUsedContainer {
-    flex: 2;
+    flex: 1.5;
 }
 
 .mostUsedTowers {


### PR DESCRIPTION
By popular request, at the end of Season 16 I saved the total wins and losses of 1233 previous HoM players to JSON so that it could be used to calculate players' seasonal winrates here. The seasonal winrate will display next to the lifetime winrate on a players' profile if the player has data stored.